### PR TITLE
ファイル名のゼロ埋め桁数の算出処理を変更

### DIFF
--- a/metadata.py
+++ b/metadata.py
@@ -56,7 +56,7 @@ def get_attribute_metadata(metadata_path):
     df.columns = [clean_attributes(col) for col in df.columns]
 
     # Get zfill count based on number of images generated
-    zfill_count = len(str(df.shape[0]))
+    zfill_count = len(str(df.shape[0] - 1))
 
     return df, zfill_count
 


### PR DESCRIPTION
## 変更内容
Jsonファイル生成時のゼロ埋め桁数の算出処理について、  
csvの行数から-1するよう変更
## 背景
nft.pyで出力した画像ファイルの数が10,100,1000...といった桁数が変わる閾値である場合、  
metadata.pyでJsonに出力する画像ファイル名とで差異が生じます。
そのため、nft.py側に合わせcount - 1しました。
https://github.com/unchain-dev/generative-nft-library/blob/master/nft.py#L158

## 備考

<!-- 該当ページの URL -->
関連する学習コンテンツ
https://app.unchain.tech/learn/Polygon-Generative-NFT/section-1_lesson-1
https://app.unchain.tech/learn/Polygon-Generative-NFT/section-1_lesson-2
